### PR TITLE
Added should work until in report

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -115,6 +115,10 @@ const report = (args, options, logger, date) => {
               // renders the table
               console.log(table)
 
+              if (!data.end) {
+                helpers.shouldWorkUntil(data.start, config)
+              }
+
               spinnerInfo(spinner, constants.TEXT.helpTip)
               process.exit(0)
             }


### PR DESCRIPTION
Now the single report shows the work until time to a full day if the clock out isn't set yet.
Example:
![code_2018-05-13_18-09-08](https://user-images.githubusercontent.com/15911342/39969756-257dc7d2-56e1-11e8-8032-1f4b967def69.png)
